### PR TITLE
[WIP] Add a "spider" test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,13 @@ For an entry `base_path,hits`, each worker requests `base_path` `ceil(hits * fac
 
 ### govuk.Spider
 
-**Properties:** `steps` (default: 10), the number of links to follow (not including the / page)
+**Properties:**
 
-Each worker loads the / page, then follows random links until they have followed `steps` links.
+- `minSteps` (default: 5), the minimum number of links to follow
+- `maxSteps` (default: 50), the maximum number of links to follow
+- `steps` (default: unset), the number of links to follow, overrides `minSteps` and `maxSteps`
+
+Each worker selects a random number of links to follow between `minSteps` and `maxSteps` inclusive (or `steps`, if given), and follows randomly selected links, starting from the / page.
 
 
 Troubleshooting

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Choose a simulation number:
      [4] computerdatabase.advanced.AdvancedSimulationStep04
      [5] computerdatabase.advanced.AdvancedSimulationStep05
      [6] govuk.Frontend
+     [7] govuk.Spider
 ```
 
 "computerdatabase" is a collection of example test plans for http://computer-database.gatling.io
@@ -87,6 +88,12 @@ Tets plans live in the `test-plans` directory.  Their data files live in the `te
 **Properties:** `factor` (default: 1), the multiplier to apply to the amount of desired traffic
 
 For an entry `base_path,hits`, each worker requests `base_path` `ceil(hits * factor / workers)` times, with no delay between requests.  Each worker proceeds through the csv in order.
+
+### govuk.Spider
+
+**Properties:** `steps` (default: 10), the number of links to follow (not including the / page)
+
+Each worker loads the / page, then follows random links until they have followed `steps` links.
 
 
 Troubleshooting

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ For an entry `base_path,hits`, each worker requests `base_path` `ceil(hits * fac
 - `minSteps` (default: 5), the minimum number of links to follow
 - `maxSteps` (default: 50), the maximum number of links to follow
 - `steps` (default: unset), the number of links to follow, overrides `minSteps` and `maxSteps`
+- `startPage` (default: "/"), the page to start from
 
 Each worker selects a random number of links to follow between `minSteps` and `maxSteps` inclusive (or `steps`, if given), and follows randomly selected links, starting from the / page.
 

--- a/test-plans/Spider.scala
+++ b/test-plans/Spider.scala
@@ -8,6 +8,7 @@ class Spider extends Simulation {
   val minSteps = sys.props.getOrElse("minSteps", "5").toInt
   val maxSteps = sys.props.getOrElse("maxSteps", "50").toInt
   val steps = sys.props.get("steps")
+  val startPage = sys.props.getOrElse("startPage", "/")
 
   val stepper = Iterator.continually(Map("steps" -> (steps match {
     // giving a "steps" value overrides the min/max steps
@@ -20,7 +21,7 @@ class Spider extends Simulation {
     scenario("Spider")
       .feed(cachebuster)
       .feed(stepper)
-      .exec(session => session.set("href", "/"))
+      .exec(session => session.set("href", startPage))
       .repeat("${steps}", "step") {
         exec(
           get("${href}",

--- a/test-plans/Spider.scala
+++ b/test-plans/Spider.scala
@@ -2,15 +2,26 @@ package govuk
 
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
+import scala.util.Random
 
 class Spider extends Simulation {
-  val steps = sys.props.getOrElse("steps", "10").toInt
+  val minSteps = sys.props.getOrElse("minSteps", "5").toInt
+  val maxSteps = sys.props.getOrElse("maxSteps", "50").toInt
+  val steps = sys.props.get("steps")
+
+  val stepper = Iterator.continually(Map("steps" -> (steps match {
+    // giving a "steps" value overrides the min/max steps
+    case Some(value) => value.toInt
+    // +1 because the upper bound of 'nextInt' is exclusive
+    case None => Random.nextInt(1 + maxSteps - minSteps) + minSteps
+  })))
 
   val scn =
     scenario("Spider")
       .feed(cachebuster)
+      .feed(stepper)
       .exec(session => session.set("href", "/"))
-      .repeat(steps, "step") {
+      .repeat("${steps}", "step") {
         exec(
           get("${href}",
               "${cachebust}-${step}",

--- a/test-plans/Spider.scala
+++ b/test-plans/Spider.scala
@@ -1,0 +1,21 @@
+package govuk
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+class Spider extends Simulation {
+  val steps = sys.props.getOrElse("steps", "10").toInt
+
+  val scn =
+    scenario("Spider")
+      .feed(cachebuster)
+      .exec(session => session.set("href", "/"))
+      .repeat(steps, "step") {
+        exec(
+          get("${href}",
+              "${cachebust}-${step}",
+              Seq(css("""a[href^="/"]""", "href").findRandom.saveAs("href"))))
+      }
+
+  run(scn)
+}


### PR DESCRIPTION
Workers randomly explore links on the site, as if it were being crawled by something.

There's a gatling bug about redirects and HTTP auth.  It's been fixed, but we should wait for a new release before merging this PR, as it trips it reasonably frequently.

---

**To do:** requests to non-html pages (eg, css or images) register as a failure, because the returned resource doesn't have the `govuk:rendering-application` meta tag.  Either the checks should be amended so that this isn't a problem, or the spider should detect the non-html content type and go back to the previous page.