### PR TITLE
Add whitehall publishing scenario

### DIFF
--- a/test-plans/WhitehallPublishing.scala
+++ b/test-plans/WhitehallPublishing.scala
@@ -1,0 +1,129 @@
+package govuk
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+import scala.util.Random
+
+class WhitehallPublishing extends Simulation {
+  val factor = sys.props.getOrElse("factor", "1").toFloat
+  val scale = factor / workers
+  val signonUrl = sys.props.get("signonUrl").get + "/users/sign_in"
+
+  val scn =
+    scenario("Publishing Whitehall guidance")
+      .exec(
+        http("Visit signon")
+          .get(signonUrl)
+          .check(status.is(200))
+          .check(
+            regex("Sign in to GOV.UK").exists,
+            css("input[name=authenticity_token]", "value").saveAs("authToken")
+          )
+      )
+      .exec(
+        http("Authenticate in signon")
+          .post(signonUrl)
+          .formParam("authenticity_token", """${authToken}""")
+          .formParam("user[email]", sys.env.get("USERNAME").get)
+          .formParam("user[password]", sys.env.get("PASSWORD").get)
+          .check(status.is(200))
+      )
+      .exec(
+        http("Visit Whitehall admin backend")
+          .get("/government/admin")
+          .check(status.is(200))
+          .check(regex("GOV.UK Whitehall").exists)
+          .check(regex("New document").exists)
+      )
+      .exec(
+        http("Visit new case study form")
+          .get("/government/admin/case-studies/new")
+          .check(status.is(200))
+          .check(regex("Create case study").exists)
+          .check(
+            css("input[name=authenticity_token]", "value").saveAs("authToken")
+          )
+      )
+      .exec(session => {
+        session.set("randomInt", Random.nextInt(Integer.MAX_VALUE))
+      })
+      .exec(
+        http("Save a draft case study")
+          .post("/government/admin/case-studies")
+          .formParam("authenticity_token", """${authToken}""")
+          .formParam("edition[title]", """Gatling test case study ${randomInt}""")
+          .formParam("edition[summary]", "Gatling test case study")
+          .formParam("edition[body]", """## Gatling test case study
+
+            TODO: Method to generate realistic case study body.
+            This isn't enough text to emulate the sort of payload Whitehall would
+            typically send for a case study"""
+          )
+          .formParam("edition[previously_published]", "false")
+          .formParam("edition[lead_organisation_ids][]", "1056")
+      )
+      .pause(2)
+      .exec(
+        http("Visit documents index")
+          .get("/government/admin/editions?organisation=1056&state=active")
+          .check(status.is(200))
+          .check(regex("My department’s documents").exists)
+          .check(
+            css("""a[title='View document Gatling test case study ${randomInt}']""", "href").saveAs("caseStudyLink")
+          )
+      )
+      .pause(2)
+      .exec(
+        http("Edit draft")
+          .get("""${caseStudyLink}""")
+          .check(status.is(200))
+          .check(
+            css(".taxonomy-topics a.btn-default", "href").saveAs("addTagsLink"),
+            css(".force-publish-form", "action").saveAs("forcePublishAction"),
+            css(".force-publish-form input[name=authenticity_token]", "value").saveAs("forcePublishAuthToken")
+          )
+      )
+      .exec(
+        http("Edit draft tags")
+          .get("""${addTagsLink}""")
+          .check(status.is(200))
+          .check(
+            css(".new_taxonomy_tag_form", "action").saveAs("saveTagsAction"),
+            css(".new_taxonomy_tag_form input[name=authenticity_token]", "value").saveAs("authToken")
+          )
+      )
+      /*
+       * Example debugging EL vars as they are saved to the Gatling session
+      .exec(session => {
+        val addTagsLink = session("addTagsLink").as[String]
+        println(s"addTagsLink: $addTagsLink")
+        val saveTagsAction = session("saveTagsAction").as[String]
+        println(s"saveTagsAction: $saveTagsAction")
+        val forcePublishAction = session("forcePublishAction").as[String]
+        println(s"forcePublishAction: $forcePublishAction")
+        session
+      })
+      */
+      .exec(
+        http("Update draft tags")
+          .put("""${saveTagsAction}""")
+          .formParam("authenticity_token", """${authToken}""")
+          .formParam("taxonomy_tag_form[previous_version]", "1")
+          .formParam("taxonomy_tag_form[taxons][]", "e48ab80a-de80-4e83-bf59-26316856a5f9") // Could select these.
+          .formParam("taxonomy_tag_form[taxons][]", "67f50352-bc30-482f-a2d0-a05714e3cea8")
+          .check(status.is(200))
+      )
+      .pause(2)
+      .exec(
+        http("Force publish case study")
+          .post("""${forcePublishAction}""")
+          .formParam("authenticity_token", """${forcePublishAuthToken}""")
+          .formParam("reason", "Gatling load test run")
+          .formParam("commit", "Force publish")
+          .check(status.is(200))
+      )
+
+    // This is a proof of concept so limit to 1 request
+    // this can be scaled up with the usual call of `run(scn)`
+    setUp(scn.inject(atOnceUsers(1))).protocols(httpProtocol)
+}

--- a/test-plans/WhitehallPublishing.scala
+++ b/test-plans/WhitehallPublishing.scala
@@ -17,71 +17,103 @@ class WhitehallPublishing extends Simulation {
           .check(status.is(200))
           .check(
             regex("Sign in to GOV.UK").exists,
-            css("input[name=authenticity_token]", "value").saveAs("authToken")
+            css("input[name=authenticity_token]", "value").saveAs("signonAuthToken")
           )
       )
       .exec(
         http("Authenticate in signon")
           .post(signonUrl)
-          .formParam("authenticity_token", """${authToken}""")
+          .formParam("authenticity_token", """${signonAuthToken}""")
           .formParam("user[email]", sys.env.get("USERNAME").get)
           .formParam("user[password]", sys.env.get("PASSWORD").get)
           .check(status.is(200))
       )
       .exec(
-        http("Visit Whitehall admin backend")
-          .get("/government/admin")
+        http("Draft a new publication")
+          .get("/government/admin/publications/new")
           .check(status.is(200))
-          .check(regex("GOV.UK Whitehall").exists)
-          .check(regex("New document").exists)
-      )
-      .exec(
-        http("Visit new case study form")
-          .get("/government/admin/case-studies/new")
-          .check(status.is(200))
-          .check(regex("Create case study").exists)
+          .check(regex("Create publication").exists)
           .check(
             css("input[name=authenticity_token]", "value").saveAs("authToken")
           )
       )
       .exec(session => {
-        session.set("randomInt", Random.nextInt(Integer.MAX_VALUE))
+        val randomInt = Random.nextInt(Integer.MAX_VALUE)
+        session.set("randomInt", randomInt)
+        session.set("publicationTitle", s"Gatling test publication $randomInt")
       })
       .exec(
-        http("Save a draft case study")
-          .post("/government/admin/case-studies")
+        http("Save a draft publication")
+          .post("/government/admin/publications")
           .formParam("authenticity_token", """${authToken}""")
-          .formParam("edition[title]", """Gatling test case study ${randomInt}""")
-          .formParam("edition[summary]", "Gatling test case study")
-          .formParam("edition[body]", """## Gatling test case study
+          .formParam("edition[publication_type_id]", "3")
+          .formParam("edition[title]", """${publicationTitle}""")
+          .formParam("edition[summary]", """${publicationTitle} summary text""")
+          .formParam("edition[body]", """## This is a test publication
 
-            TODO: Method to generate realistic case study body.
+            TODO: Something to generate and/or include realistic content body.
             This isn't enough text to emulate the sort of payload Whitehall would
-            typically send for a case study"""
+            typically send for a document"""
           )
           .formParam("edition[previously_published]", "false")
           .formParam("edition[lead_organisation_ids][]", "1056")
       )
-      .pause(2)
       .exec(
         http("Visit documents index")
           .get("/government/admin/editions?organisation=1056&state=active")
           .check(status.is(200))
           .check(regex("My department’s documents").exists)
           .check(
-            css("""a[title='View document Gatling test case study ${randomInt}']""", "href").saveAs("caseStudyLink")
+            css("""a[title='View document ${publicationTitle}']""", "href").saveAs("publicationLink")
           )
       )
-      .pause(2)
       .exec(
-        http("Edit draft")
-          .get("""${caseStudyLink}""")
+        http("Draft overview")
+          .get("""${publicationLink}""")
           .check(status.is(200))
           .check(
             css(".taxonomy-topics a.btn-default", "href").saveAs("addTagsLink"),
+            css(".edition-view-edit-buttons a.btn-default", "href").saveAs("editDraftLink"),
             css(".force-publish-form", "action").saveAs("forcePublishAction"),
             css(".force-publish-form input[name=authenticity_token]", "value").saveAs("forcePublishAuthToken")
           )
+      )
+      .exec(
+        http("Edit draft")
+          .get("""${editDraftLink}""")
+          .check(status.is(200))
+          .check(regex("Edit publication").exists)
+          .check(
+            css(".nav-tabs li:nth-of-type(2) a", "href").saveAs("attachmentsLink")
+          )
+      )
+      .exec(
+        http("Visit HTML attachment form")
+          .get("""${attachmentsLink}/new?type=html""")
+          .check(status.is(200))
+          .check(
+            css("#new_attachment", "action").saveAs("attachmentFormAction"),
+            css("#new_attachment input[name=authenticity_token]", "value").saveAs("attachmentAuthToken")
+          )
+      )
+      .exec(
+        http("Add HTML attachment")
+          .post("""${attachmentFormAction}""")
+          .formParam("authenticity_token", """${attachmentAuthToken}""")
+          .formParam("type", "html")
+          .formParam("attachment[title]", """${publicationTitle} attachment""")
+          .formParam("attachment[govspeak_content_attributes][body]", """
+            ### ${publicationTitle} Attachment
+
+            Some html attachment text.
+            Maybe some govspeak:
+
+            - This
+            - That
+            - Something else
+          """
+          )
+          .check(status.is(200))
       )
       .exec(
         http("Edit draft tags")
@@ -92,18 +124,6 @@ class WhitehallPublishing extends Simulation {
             css(".new_taxonomy_tag_form input[name=authenticity_token]", "value").saveAs("authToken")
           )
       )
-      /*
-       * Example debugging EL vars as they are saved to the Gatling session
-      .exec(session => {
-        val addTagsLink = session("addTagsLink").as[String]
-        println(s"addTagsLink: $addTagsLink")
-        val saveTagsAction = session("saveTagsAction").as[String]
-        println(s"saveTagsAction: $saveTagsAction")
-        val forcePublishAction = session("forcePublishAction").as[String]
-        println(s"forcePublishAction: $forcePublishAction")
-        session
-      })
-      */
       .exec(
         http("Update draft tags")
           .put("""${saveTagsAction}""")
@@ -113,14 +133,19 @@ class WhitehallPublishing extends Simulation {
           .formParam("taxonomy_tag_form[taxons][]", "67f50352-bc30-482f-a2d0-a05714e3cea8")
           .check(status.is(200))
       )
-      .pause(2)
       .exec(
-        http("Force publish case study")
+        http("Force publish publication")
           .post("""${forcePublishAction}""")
           .formParam("authenticity_token", """${forcePublishAuthToken}""")
           .formParam("reason", "Gatling load test run")
           .formParam("commit", "Force publish")
           .check(status.is(200))
+      )
+      .exec(
+        http("Visit publication overview")
+          .get("""${publicationLink}""")
+          .check(status.is(200))
+          .check(regex("Force published: Gatling load test run").exists)
       )
 
     // This is a proof of concept so limit to 1 request


### PR DESCRIPTION
https://trello.com/c/vK1OZjH4/4-spike-can-we-run-one-test-scenario

![screenshot from 2018-12-20 16-43-22](https://user-images.githubusercontent.com/93511/50298175-68a7f300-0476-11e9-99a3-1d9aa161281a.png)

Proof of concept to show we can interact with Signon and Whitehall publisher.

- Authenticates via Signon
- Creates a draft publication
- Adds an HTML attachment to the publication
- Tags the publication to the taxonomy
- Force publishes the publication

Requires `JAVA_OPTS` to include urls like 
```
-DbaseUrl=https://whitehall-admin.integration.publishing.service.gov.uk -DsignonUrl=https://signon.integration.publishing.service.gov.uk
```

Environment vars `USERNAME` and `PASSWORD` are used to authenticate with signon.

### TODO:

- Add realistic content when performing workflow steps, this is covered in a separate story here: https://trello.com/c/qS5XdJGw/20-start-generating-test-data-for-concurrent-publishing-load-testing