### PR TITLE
Enable whitehall publishing scenarios

### DIFF
--- a/test-plans/WhitehallPublishing.scala
+++ b/test-plans/WhitehallPublishing.scala
@@ -106,7 +106,5 @@ class WhitehallPublishing extends Simulation {
           .check(regex("Force published: Gatling load test run").exists)
       )
 
-    // This is a proof of concept so limit to 1 request
-    // this can be scaled up with the usual call of `run(scn)`
-    setUp(scn.inject(atOnceUsers(1))).protocols(httpProtocol)
+  run(scn)
 }

--- a/test-plans/WhitehallPublishing.scala
+++ b/test-plans/WhitehallPublishing.scala
@@ -39,15 +39,8 @@ class WhitehallPublishing extends Simulation {
           .formParam("edition[body]", s"""## Gatling test content\n\n${lipsum.text}""")
           .formParam("edition[previously_published]", "false")
           .formParam("edition[lead_organisation_ids][]", "1056")
-      )
-      .exec(
-        http("Visit documents index")
-          .get("/government/admin/editions?organisation=1056&state=active")
           .check(status.is(200))
-          .check(regex("My department’s documents").exists)
-          .check(
-            css("""a[title='View document ${publicationTitle}']""", "href").saveAs("publicationLink")
-          )
+          .check(css(".form-actions span.or_cancel a", "href").saveAs("publicationLink"))
       )
       .exec(
         http("Draft overview")

--- a/test-plans/WhitehallPublishingCollections.scala
+++ b/test-plans/WhitehallPublishingCollections.scala
@@ -25,8 +25,10 @@ class WhitehallPublishingCollections extends Simulation {
       )
       .exec(session => {
         val randomInt = Random.nextInt(Integer.MAX_VALUE)
-        session.set("randomInt", randomInt)
-        session.set("collectionTitle", s"Gatling test collection $randomInt")
+        session.setAll(
+          "randomInt" -> randomInt,
+          "collectionTitle" -> s"Gatling test collection $randomInt"
+        )
       })
       .exec(
         http("Save a draft collection")
@@ -38,15 +40,8 @@ class WhitehallPublishingCollections extends Simulation {
           .formParam("edition[body]", s"""## Gatling test collection\n\n${lipsum.text}""")
           .formParam("edition[previously_published]", "false")
           .formParam("edition[lead_organisation_ids][]", "1056")
-      )
-      .exec(
-        http("Visit documents index")
-          .get("/government/admin/editions?organisation=1056&state=active")
           .check(status.is(200))
-          .check(regex("My department’s documents").exists)
-          .check(
-            css("""a[title='View document ${collectionTitle}']""", "href").saveAs("collectionLink")
-          )
+          .check(css(".form-actions span.or_cancel a", "href").saveAs("collectionLink"))
       )
       .exec(
         http("Draft collection overview")

--- a/test-plans/WhitehallPublishingCollections.scala
+++ b/test-plans/WhitehallPublishingCollections.scala
@@ -112,7 +112,5 @@ class WhitehallPublishingCollections extends Simulation {
           .check(regex("Force published: Gatling load test run").exists)
       )
 
-    // This is a proof of concept so limit to 1 request
-    // this can be scaled up with the usual call of `run(scn)`
-    setUp(scn.inject(atOnceUsers(1))).protocols(httpProtocol)
+  run(scn)
 }


### PR DESCRIPTION
Part of https://trello.com/c/eev4C0vF/22-load-test-publishing-apps-and-pipeline

![screenshot from 2019-01-04 10-31-09](https://user-images.githubusercontent.com/93511/50683977-e7229a00-100b-11e9-818e-3000c16aef4d.png)


After a few preliminary tests yesterday a couple of small issues were spotted.
The main problem was that at scale, tests which created a draft document couldn't rely on the Whitehall documents index to 'find' the newly created item as this page is limited in the number of results it displays.

I was able to run this branch with ~100 workers successfully.