### PR TITLE
Make document search repetition configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Steps:
 
 **Requires:** `signonUrl` property. `USERNAME` and `PASSWORD` environment variables.
 
+**Optional:** `documentSearches` property - How many document searches to make when adding to the collection.
+
 Steps:
 
 - Authenticates with signon


### PR DESCRIPTION
https://trello.com/c/eev4C0vF/22-load-test-publishing-apps-and-pipeline

Document searches are a weak spot in the document collection scenario as the searches often timeout.
Make the number of searches to perform per user a configurable property.