### PR TITLE
Simplify running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ The installation steps are:
 1. Clone this repository into your `~/govuk/` directory
 1. [Download](https://gatling.io/download/) and extract Gatling, these test plans are written for version 3
 1. Rename and move the extracted Gatling directory to `~/govuk/gatling` to make it available in `/var/govuk/gatling` in your Virtual Machine
-1. Symlink the `src/test/resources/test-data` directory of this repository to `$GATLING_HOME/user-files/resources/`
-  ```
-  $ ln -s ~/govuk/govuk-load-testing/src/test/resources/test-data ~/govuk/gatling/user-files/resources/
-  ```
 1. Set the needed environment variables:
   - `$ export 'JAVA_OPTS=<required-options>'` (see [Configuration Options](#configuration))
   - `$ export 'GATLING_USERNAME=<test-user-email>'`
@@ -54,20 +50,16 @@ In order to run a simulation plan, Gatling provides a wrapper script to compile 
 You can run Gatling by:
 1. running the following command:
   ```
-  $ $GATLING_HOME/bin/gatling.sh
+  $ $GATLING_HOME/bin/gatling.sh -sf src/test/scala
   ```
   **Note:** This command must be run from within `~/govuk/govuk-load-testing` (or `/var/govuk/govuk-load-testing` if you are using the Virtual Machine).
 
 2. selecting the simulation plan number that you wish to run.
   ```
   Choose a simulation number:
-      [0] computerdatabase.BasicSimulation
-      [1] computerdatabase.advanced.AdvancedSimulationStep01
-      [2] computerdatabase.advanced.AdvancedSimulationStep02
-      [3] computerdatabase.advanced.AdvancedSimulationStep03
-      [4] computerdatabase.advanced.AdvancedSimulationStep04
-      [5] computerdatabase.advanced.AdvancedSimulationStep05
-      [6] govuk.Frontend
+      [0] govuk.Frontend
+      [1] govuk.WhitehallPublishing
+      [2] govuk.WhitehallPublishingCollections
   ```
   A description of relevant simulation plans available for the gov.uk website
   is available [here](#plans)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The property `signonUrl` and environment variables `GATLING_USERNAME` and `GATLI
 
 The following properties are optional:
 
-- `dataDir` (default: "test-data"), the directory to look in for test data files
+- `dataDir` (default: "src/test/resources/test-data"), the directory to look in for test data files
 - `rateLimitToken` (default: no header sent), the value of the `Rate-Limit-Token` header
 - `workers` (default: 1), the number of threads making requests
 - `ramp` (default: 0), the duration, in seconds, over which the workers are started

--- a/src/test/scala/govuk/Simulation.scala
+++ b/src/test/scala/govuk/Simulation.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import scala.util.Random
 
 abstract class Simulation extends scenario.Simulation {
-  val dataDir = sys.props.getOrElse("dataDir", "test-data")
+  val dataDir = sys.props.getOrElse("dataDir", "src/test/resources/test-data")
   val baseUrl = sys.props.get("baseUrl").get
   val username = sys.props.getOrElse("username", "")
   val password = sys.props.getOrElse("password", "")

--- a/test-data
+++ b/test-data
@@ -1,1 +1,0 @@
-src/test/resources/test-data/


### PR DESCRIPTION
We don't need to set up symlinks anymore, instead we can just use the `-sf` option.