### PR TITLE
Add some docs on uploading results to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Test plans for load testing GOV.UK frontend apps using [Gatling](https://gatling
   2.3 [Rental of an enterprise Gatling Instance via AWS Marketplace](#aws-gatling)
 3. [Configuration Options](#configuration)
 4. [Simulation Plans](#plans)
-5. [Troubleshooting](#troubleshooting)
+5. [Uploading](#uploading)
+6. [Troubleshooting](#troubleshooting)
 
 
 # <a name="terminology">1. Terminology </a>
@@ -287,7 +288,14 @@ while their data files live in the `src/test/resources` directory.
     - Tags to taxonomy
     - Force publishes
 
-## <a name="troubleshooting">5. Troubleshooting</a>
+## <a name="uploading">5. Uploading</a>
+
+See [how to upload results][uploading-results] for more information on how to
+upload results so they are easy to access in the future.
+
+[uploading-results]: https://github.com/alphagov/govuk-load-testing/blob/master/docs/uploading.md
+
+## <a name="troubleshooting">6. Troubleshooting</a>
 
 1. **My requests are being rate limited**
 

--- a/docs/uploading.md
+++ b/docs/uploading.md
@@ -1,0 +1,64 @@
+# Uploading results
+
+To make sure that load testing results are available again in the future, we
+can upload the results to an S3 bucket. This is especially useful if we need to
+reprovision the Gatling machine which means we lose the results kept on the
+machine itself.
+
+## 1. Find a good place to upload the results
+
+The S3 bucket to store the results in Staging is
+[`gatling-results-staging`][bucket]. In the future we might have buckets in
+other environments, but for now, load testing has only been happening against
+staging.
+
+[bucket]: https://s3.console.aws.amazon.com/s3/buckets/gatling-results-staging/?region=eu-west-2&tab=overview
+
+To make sure results are easy to find in the future, make sure to follow the
+existing directory structure:
+
+```erb
+/<%= test_plan %>/<%= date %>-<%= number_of_workers %>-workers-%<= number_of_seconds %>-seconds
+```
+
+If it makes sense to deviate from the number of workers and number of seconds
+format (if different parameters are used) then that's fine.
+
+An example of a good upload path:
+`/dynamic-lists/2019-09-05-80000-workers-600-seconds`
+
+## 1. Get the results off the Gatling machine
+
+After the load test has finished, Gatling will tell you where to find the
+results. Something like this:
+
+```sh
+Reports generated in 285s.
+Please open the following file: /usr/local/bin/gatling/results/dynamiclists-20190906091551610/index.html
+gatling@ec2-staging-govuk-gatling-ip-10-12-4-83:/usr/local/bin/gatling$
+```
+
+You can use `scp` to copy that onto your own computer ready for uploading:
+
+```sh
+$ scp -r 10.12.4.83.staging-aws:/usr/local/bin/gatling/results/dynamiclists-20190906091551610 ~/Downloads
+```
+
+## 1. Upload Gatling HTML files
+
+Once you have a place to upload the results, all you need to do is upload all
+the HTML, CSS and JS files that are part of a Gatling results directory.
+
+You can do this using the S3 web interface, by clicking the "Upload" button
+once you're in the right directory. You can leave all the upload settings as
+the defaults.
+
+## 1. Test the results can be seen
+
+When the upload has finished, it should be possible to view the results by
+going to:
+
+https://gatling-results-staging.s3-eu-west-1.amazonaws.com/<directory>/index.html
+
+**Note:** you will need to be either in the office or connected to the VPN to
+see the results.


### PR DESCRIPTION
Since https://github.com/alphagov/govuk-aws/pull/1098 we now have to bucket to store results for a longer period of time.

[Trello Card](https://trello.com/c/Juuu8OvE/1251-5-host-the-gatling-reports-graphs-somewhere)