### PR TITLE
Encourage people to record the Gatling command they used

### DIFF
--- a/docs/uploading.md
+++ b/docs/uploading.md
@@ -27,7 +27,20 @@ format (if different parameters are used) then that's fine.
 An example of a good upload path:
 `/dynamic-lists/2019-09-05-80000-workers-600-seconds`
 
-## 1. Get the results off the Gatling machine
+## 2. Make a record of the Gatling command
+
+To make it easy to re-run a load test again, it would be useful to make a
+record of the command being run for the test. You can store that in a file
+called `command.txt`.
+
+**Note:** you should remove any secrets from the command before saving it, for
+example rate limiting tokens.
+
+It may also be relevant to store information about the infrastructure at the
+time the command was run, for example if an unusual number of frontend machines
+were provisioned.
+
+## 3. Get the results off the Gatling machine
 
 After the load test has finished, Gatling will tell you where to find the
 results. Something like this:
@@ -44,7 +57,7 @@ You can use `scp` to copy that onto your own computer ready for uploading:
 $ scp -r 10.12.4.83.staging-aws:/usr/local/bin/gatling/results/dynamiclists-20190906091551610 ~/Downloads
 ```
 
-## 1. Upload Gatling HTML files
+## 4. Upload Gatling HTML files
 
 Once you have a place to upload the results, all you need to do is upload all
 the HTML, CSS and JS files that are part of a Gatling results directory.
@@ -53,7 +66,9 @@ You can do this using the S3 web interface, by clicking the "Upload" button
 once you're in the right directory. You can leave all the upload settings as
 the defaults.
 
-## 1. Test the results can be seen
+Don't forget to upload your `command.txt` file as well.
+
+## 5. Test the results can be seen
 
 When the upload has finished, it should be possible to view the results by
 going to:


### PR DESCRIPTION
This should make it easier to re-run the command again afterwards.

[Trello Card](https://trello.com/c/hLcXe1zf/1249-2-define-a-way-to-store-gatling-run-commands-for-each-test)