### PR TITLE
Reduce duplication in scenarios

### DIFF
--- a/src/test/scala/govuk/BusinessReadinessFinder.scala
+++ b/src/test/scala/govuk/BusinessReadinessFinder.scala
@@ -5,7 +5,6 @@ import io.gatling.http.Predef._
 
 class BusinessReadinessFinder extends Simulation {
   val factor = sys.props.getOrElse("factor", "1").toFloat
-
   val duration = sys.props.getOrElse("duration", "0").toInt
 
   val paths = csv(dataDir + java.io.File.separatorChar + "business-readiness-paths.csv").readRecords

--- a/src/test/scala/govuk/BusinessReadinessFinder.scala
+++ b/src/test/scala/govuk/BusinessReadinessFinder.scala
@@ -22,9 +22,9 @@ class BusinessReadinessFinder extends Simulation {
           }
       }
 
-  val scn_with_duration =
+  val scnWithDuration =
     scenario("BusinessReadinessFinder")
-      .during(duration, "Soak test"){
+      .during(duration, "Soak test") {
         feed(cachebuster)
         .foreach(paths, "path") {
           exec(flattenMapIntoAttributes("${path}"))
@@ -35,9 +35,5 @@ class BusinessReadinessFinder extends Simulation {
         }
       }
 
-  if(duration > 0){
-    run(scn_with_duration)
-  } else{
-    run(scn)
-  }
+  if (duration == 0) run(scn) else run(scnWithDuration)
 }

--- a/src/test/scala/govuk/DynamicLists.scala
+++ b/src/test/scala/govuk/DynamicLists.scala
@@ -5,7 +5,6 @@ import io.gatling.http.Predef._
 
 class DynamicLists extends Simulation {
   val factor = sys.props.getOrElse("factor", "1").toFloat
-
   val duration = sys.props.getOrElse("duration", "0").toInt
 
   val paths = csv(dataDir + java.io.File.separatorChar + "get-ready-brexit-check_paths.csv").readRecords

--- a/src/test/scala/govuk/DynamicLists.scala
+++ b/src/test/scala/govuk/DynamicLists.scala
@@ -22,9 +22,9 @@ class DynamicLists extends Simulation {
           }
       }
 
-  val scn_with_duration =
+  val scnWithDuration =
     scenario("DynamicLists")
-      .during(duration, "Soak test"){
+      .during(duration, "Soak test") {
         feed(cachebuster)
         .foreach(paths, "path") {
           exec(flattenMapIntoAttributes("${path}"))
@@ -35,9 +35,5 @@ class DynamicLists extends Simulation {
         }
       }
 
-  if(duration > 0){
-    run(scn_with_duration)
-  } else{
-    run(scn)
-  }
+  if (duration == 0) run(scn) else run(scnWithDuration)
 }

--- a/src/test/scala/govuk/DynamicListsEmailSignup.scala
+++ b/src/test/scala/govuk/DynamicListsEmailSignup.scala
@@ -14,11 +14,11 @@ class DynamicListsEmailSignup extends Simulation {
   val subscribe = exec(
     http("Subscribe")
       .post("""${subscribeFormAction}""")
-      .formParam("authenticity_token", """${subscribeAuthToken}""")
+      .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
       .check(
-        css(".checklist-email-signup", "action").saveAs("frequencyLink"),
-        css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionTopicId"),
-        css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+        css(".checklist-email-signup", "action").saveAs("emailAlertFrontendUrl"),
+        css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailAlertFrontendTopicId"),
+        css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
       )
       .check(status.is(200))
   )
@@ -33,7 +33,7 @@ class DynamicListsEmailSignup extends Simulation {
               get("${base_path}", "${cachebust}-${hit}")
                 .check(
                   css("#checklist-email-signup", "action").saveAs("subscribeFormAction"),
-                  css("#checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+                  css("#checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                 )
                 .check(status.is(200))
             )
@@ -53,7 +53,7 @@ class DynamicListsEmailSignup extends Simulation {
                 get("${base_path}", "${cachebust}-${hit}")
                   .check(
                     css("#checklist-email-signup", "action").saveAs("subscribeFormAction"),
-                    css("#checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+                    css("#checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
                   .check(status.is(200))
               )

--- a/src/test/scala/govuk/DynamicListsEmailSignup.scala
+++ b/src/test/scala/govuk/DynamicListsEmailSignup.scala
@@ -5,7 +5,6 @@ import io.gatling.http.Predef._
 
 class DynamicListsEmailSignup extends Simulation {
   val factor = sys.props.getOrElse("factor", "1").toFloat
-
   val duration = sys.props.getOrElse("duration", "0").toInt
 
   val paths = csv(dataDir + java.io.File.separatorChar + "get-ready-brexit-check-email-signup_paths.csv").readRecords

--- a/src/test/scala/govuk/DynamicListsEmailSignup.scala
+++ b/src/test/scala/govuk/DynamicListsEmailSignup.scala
@@ -64,9 +64,9 @@ class DynamicListsEmailSignup extends Simulation {
           }
       }
 
-  val scn_with_duration =
+  val scnWithDuration =
     scenario("DynamicListsEmailSignup")
-      .during(duration, "Soak test"){
+      .during(duration, "Soak test") {
         feed(cachebuster)
         .foreach(paths, "path") {
           exec(flattenMapIntoAttributes("${path}"))
@@ -119,9 +119,5 @@ class DynamicListsEmailSignup extends Simulation {
         }
       }
 
-  if(duration > 0){
-    run(scn_with_duration)
-  } else{
-    run(scn)
-  }
+  if (duration == 0) run(scn) else run(scnWithDuration)
 }

--- a/src/test/scala/govuk/DynamicListsEmailSignup.scala
+++ b/src/test/scala/govuk/DynamicListsEmailSignup.scala
@@ -11,6 +11,18 @@ class DynamicListsEmailSignup extends Simulation {
 
   val scale = factor / workers
 
+  val subscribe = exec(
+    http("Subscribe")
+      .post("""${subscribeFormAction}""")
+      .formParam("authenticity_token", """${subscribeAuthToken}""")
+      .check(
+        css(".checklist-email-signup", "action").saveAs("frequencyLink"),
+        css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionTopicId"),
+        css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+      )
+      .check(status.is(200))
+  )
+
   val scn =
     scenario("DynamicListsEmailSignup")
       .feed(cachebuster)
@@ -25,42 +37,8 @@ class DynamicListsEmailSignup extends Simulation {
                 )
                 .check(status.is(200))
             )
-              .exec(
-                http("POST Subscribe")
-                  .post("""${subscribeFormAction}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
-                  .check(
-                    css(".checklist-email-signup", "action").saveAs("frequencyLink"),
-                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
-                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
-                  )
-                  .check(status.is(200))
-              )
-              .exec(
-                http("POST Frequency")
-                  .post("""${frequencyLink}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
-                  .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
-                  .formParam("frequency", "immediately")
-                  .check(
-                    css(".checklist-email-signup", "action").saveAs("emailSubscriptionFrequency"),
-                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
-                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
-                  )
-                  .check(status.is(200))
-              )
-              .exec(
-                http("POST Email address")
-                  .post("""${emailSubscriptionFrequency}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
-                  .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
-                  .formParam("frequency", "immediately")
-                  .formParam("address", "alice@example.com")
-                  .check(
-                    css(".govuk-panel__title")
-                  )
-                  .check(status.is(200))
-              )
+            .exec(subscribe)
+            .exec(EmailAlertFrontend.subscribe)
           }
       }
 
@@ -79,42 +57,8 @@ class DynamicListsEmailSignup extends Simulation {
                   )
                   .check(status.is(200))
               )
-              .exec(
-                http("POST Subscribe")
-                  .post("""${subscribeFormAction}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
-                  .check(
-                    css(".checklist-email-signup", "action").saveAs("frequencyLink"),
-                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
-                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
-                  )
-                  .check(status.is(200))
-              )
-              .exec(
-                http("POST Frequency")
-                  .post("""${frequencyLink}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
-                  .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
-                  .formParam("frequency", "immediately")
-                  .check(
-                    css(".checklist-email-signup", "action").saveAs("emailSubscriptionFrequency"),
-                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
-                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
-                  )
-                  .check(status.is(200))
-              )
-              .exec(
-                http("POST Email address")
-                  .post("""${emailSubscriptionFrequency}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
-                  .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
-                  .formParam("frequency", "immediately")
-                  .formParam("address", "alice@example.com")
-                  .check(
-                    css(".govuk-panel__title")
-                  )
-                  .check(status.is(200))
-              )
+              .exec(subscribe)
+              .exec(EmailAlertFrontend.subscribe)
             }
         }
       }

--- a/src/test/scala/govuk/EmailAlertFrontend.scala
+++ b/src/test/scala/govuk/EmailAlertFrontend.scala
@@ -1,0 +1,39 @@
+package govuk
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+/**
+ * Email Alert Frontend scenario singleton object.
+ *
+ * Call 'exec(EmailAlertFrontend.subscribe)' to use in a Gatling scenario.
+ * Requires 'emailSubscriptionTopicId', 'frequencyLink', 'subscribeAuthToken'
+ * to be present in the user session.
+ */
+object EmailAlertFrontend {
+  val subscribe = exec(
+    http("Submit frequency")
+      .post("""${frequencyLink}""")
+      .formParam("authenticity_token", """${subscribeAuthToken}""")
+      .formParam("topic_id", """${emailSubscriptionTopicId}""")
+      .formParam("frequency", "immediately")
+      .check(
+        css(".checklist-email-signup", "action").saveAs("emailSubscriptionFrequency"),
+        css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionTopicId"),
+        css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+      )
+      .check(status.is(200))
+    )
+    .exec(
+      http("Submit email address")
+        .post("""${emailSubscriptionFrequency}""")
+        .formParam("authenticity_token", """${subscribeAuthToken}""")
+        .formParam("topic_id", """${emailSubscriptionTopicId}""")
+        .formParam("frequency", "immediately")
+        .formParam("address", "alice@example.com")
+        .check(
+          css(".govuk-panel__title")
+        )
+        .check(status.is(200))
+    )
+}

--- a/src/test/scala/govuk/EmailAlertFrontend.scala
+++ b/src/test/scala/govuk/EmailAlertFrontend.scala
@@ -7,28 +7,28 @@ import io.gatling.http.Predef._
  * Email Alert Frontend scenario singleton object.
  *
  * Call 'exec(EmailAlertFrontend.subscribe)' to use in a Gatling scenario.
- * Requires 'emailSubscriptionTopicId', 'frequencyLink', 'subscribeAuthToken'
+ * Requires 'emailAlertFrontendTopicId', 'emailAlertFrontendUrl', 'emailAlertFrontendAuthToken'
  * to be present in the user session.
  */
 object EmailAlertFrontend {
   val subscribe = exec(
     http("Submit frequency")
-      .post("""${frequencyLink}""")
-      .formParam("authenticity_token", """${subscribeAuthToken}""")
-      .formParam("topic_id", """${emailSubscriptionTopicId}""")
+      .post("""${emailAlertFrontendUrl}""")
+      .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
+      .formParam("topic_id", """${emailAlertFrontendTopicId}""")
       .formParam("frequency", "immediately")
       .check(
-        css(".checklist-email-signup", "action").saveAs("emailSubscriptionFrequency"),
-        css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionTopicId"),
-        css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+        css(".checklist-email-signup", "action").saveAs("emailAlertFrontendEmailUrl"),
+        css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailAlertFrontendTopicId"),
+        css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
       )
       .check(status.is(200))
     )
     .exec(
       http("Submit email address")
-        .post("""${emailSubscriptionFrequency}""")
-        .formParam("authenticity_token", """${subscribeAuthToken}""")
-        .formParam("topic_id", """${emailSubscriptionTopicId}""")
+        .post("""${emailAlertFrontendEmailUrl}""")
+        .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
+        .formParam("topic_id", """${emailAlertFrontendTopicId}""")
         .formParam("frequency", "immediately")
         .formParam("address", "alice@example.com")
         .check(

--- a/src/test/scala/govuk/Frontend.scala
+++ b/src/test/scala/govuk/Frontend.scala
@@ -5,7 +5,6 @@ import io.gatling.http.Predef._
 
 class Frontend extends Simulation {
   val factor = sys.props.getOrElse("factor", "1").toFloat
-
   val duration = sys.props.getOrElse("duration", "0").toInt
 
   val paths = csv(dataDir + java.io.File.separatorChar + "paths.csv").readRecords

--- a/src/test/scala/govuk/Frontend.scala
+++ b/src/test/scala/govuk/Frontend.scala
@@ -22,9 +22,9 @@ class Frontend extends Simulation {
           }
       }
 
-  val scn_with_duration =
+  val scnWithDuration =
     scenario("Frontend")
-      .during(duration, "Soak test"){
+      .during(duration, "Soak test") {
         feed(cachebuster)
         .foreach(paths, "path") {
           exec(flattenMapIntoAttributes("${path}"))
@@ -35,9 +35,5 @@ class Frontend extends Simulation {
         }
       }
 
-  if(duration > 0){
-    run(scn_with_duration)
-  } else{
-    run(scn)
-  }
+  if (duration == 0) run(scn) else run(scnWithDuration)
 }

--- a/src/test/scala/govuk/PublishToPublishingApi.scala
+++ b/src/test/scala/govuk/PublishToPublishingApi.scala
@@ -16,7 +16,6 @@ import scala.util.Random
  * 3. Publish
  */
 class PublishToPublishingApi extends Simulation {
-
   val lipsum = new LoremIpsum()
   val bearerToken = sys.env.get("BEARER_TOKEN").get
   val bearerTokenHeaderValue = s"Bearer $bearerToken"


### PR DESCRIPTION
This PR reduces duplication in some scenarios by pulling out common steps into functions and values. It also make the codes a bit neater in places. See individual commits for more details.

Ideally I wanted to completely remove the duplication we have between `scn` and `scnWithDuration` but I couldn't work out how to do that with the Gatling DSL and Scala. I kept seeing compilation errors related to invalid recursive types, but I couldn't find the types for the Gatling DSL documented online anywhere.