### PR TITLE
Rename variables

### DIFF
--- a/src/test/scala/govuk/DynamicListsEmailSignup.scala
+++ b/src/test/scala/govuk/DynamicListsEmailSignup.scala
@@ -21,38 +21,38 @@ class DynamicListsEmailSignup extends Simulation {
               get("${base_path}", "${cachebust}-${hit}")
                 .check(
                   css("#checklist-email-signup", "action").saveAs("subscribeFormAction"),
-                  css("#checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+                  css("#checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                 )
                 .check(status.is(200))
             )
               .exec(
                 http("POST Subscribe")
                   .post("""${subscribeFormAction}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
+                  .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .check(
                     css(".checklist-email-signup", "action").saveAs("frequencyLink"),
                     css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
-                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
                   .check(status.is(200))
               )
               .exec(
                 http("POST Frequency")
                   .post("""${frequencyLink}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
+                  .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
                   .formParam("frequency", "immediately")
                   .check(
                     css(".checklist-email-signup", "action").saveAs("emailSubscriptionFrequency"),
                     css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
-                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
                   .check(status.is(200))
               )
               .exec(
                 http("POST Email address")
                   .post("""${emailSubscriptionFrequency}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
+                  .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
                   .formParam("frequency", "immediately")
                   .formParam("address", "alice@example.com")
@@ -75,38 +75,38 @@ class DynamicListsEmailSignup extends Simulation {
                 get("${base_path}", "${cachebust}-${hit}")
                   .check(
                     css("#checklist-email-signup", "action").saveAs("subscribeFormAction"),
-                    css("#checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+                    css("#checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
                   .check(status.is(200))
               )
               .exec(
                 http("POST Subscribe")
                   .post("""${subscribeFormAction}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
+                  .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .check(
                     css(".checklist-email-signup", "action").saveAs("frequencyLink"),
                     css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
-                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
                   .check(status.is(200))
               )
               .exec(
                 http("POST Frequency")
                   .post("""${frequencyLink}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
+                  .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
                   .formParam("frequency", "immediately")
                   .check(
                     css(".checklist-email-signup", "action").saveAs("emailSubscriptionFrequency"),
                     css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
-                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("subscribeAuthToken")
+                    css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
                   .check(status.is(200))
               )
               .exec(
                 http("POST Email address")
                   .post("""${emailSubscriptionFrequency}""")
-                  .formParam("authenticity_token", """${subscribeAuthToken}""")
+                  .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
                   .formParam("frequency", "immediately")
                   .formParam("address", "alice@example.com")

--- a/src/test/scala/govuk/DynamicListsEmailSignup.scala
+++ b/src/test/scala/govuk/DynamicListsEmailSignup.scala
@@ -30,7 +30,7 @@ class DynamicListsEmailSignup extends Simulation {
                   .post("""${subscribeFormAction}""")
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .check(
-                    css(".checklist-email-signup", "action").saveAs("frequencyLink"),
+                    css(".checklist-email-signup", "action").saveAs("emailAlertFrontendUrl"),
                     css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailAlertFrontendTopicId"),
                     css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
@@ -38,7 +38,7 @@ class DynamicListsEmailSignup extends Simulation {
               )
               .exec(
                 http("POST Frequency")
-                  .post("""${frequencyLink}""")
+                  .post("""${emailAlertFrontendUrl}""")
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .formParam("topic_id", """${emailAlertFrontendTopicId}""")
                   .formParam("frequency", "immediately")
@@ -84,7 +84,7 @@ class DynamicListsEmailSignup extends Simulation {
                   .post("""${subscribeFormAction}""")
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .check(
-                    css(".checklist-email-signup", "action").saveAs("frequencyLink"),
+                    css(".checklist-email-signup", "action").saveAs("emailAlertFrontendUrl"),
                     css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailAlertFrontendTopicId"),
                     css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
@@ -92,7 +92,7 @@ class DynamicListsEmailSignup extends Simulation {
               )
               .exec(
                 http("POST Frequency")
-                  .post("""${frequencyLink}""")
+                  .post("""${emailAlertFrontendUrl}""")
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .formParam("topic_id", """${emailAlertFrontendTopicId}""")
                   .formParam("frequency", "immediately")

--- a/src/test/scala/govuk/DynamicListsEmailSignup.scala
+++ b/src/test/scala/govuk/DynamicListsEmailSignup.scala
@@ -31,7 +31,7 @@ class DynamicListsEmailSignup extends Simulation {
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .check(
                     css(".checklist-email-signup", "action").saveAs("frequencyLink"),
-                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
+                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailAlertFrontendTopicId"),
                     css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
                   .check(status.is(200))
@@ -40,11 +40,11 @@ class DynamicListsEmailSignup extends Simulation {
                 http("POST Frequency")
                   .post("""${frequencyLink}""")
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
-                  .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
+                  .formParam("topic_id", """${emailAlertFrontendTopicId}""")
                   .formParam("frequency", "immediately")
                   .check(
                     css(".checklist-email-signup", "action").saveAs("emailSubscriptionFrequency"),
-                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
+                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailAlertFrontendTopicId"),
                     css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
                   .check(status.is(200))
@@ -53,7 +53,7 @@ class DynamicListsEmailSignup extends Simulation {
                 http("POST Email address")
                   .post("""${emailSubscriptionFrequency}""")
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
-                  .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
+                  .formParam("topic_id", """${emailAlertFrontendTopicId}""")
                   .formParam("frequency", "immediately")
                   .formParam("address", "alice@example.com")
                   .check(
@@ -85,7 +85,7 @@ class DynamicListsEmailSignup extends Simulation {
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .check(
                     css(".checklist-email-signup", "action").saveAs("frequencyLink"),
-                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
+                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailAlertFrontendTopicId"),
                     css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
                   .check(status.is(200))
@@ -94,11 +94,11 @@ class DynamicListsEmailSignup extends Simulation {
                 http("POST Frequency")
                   .post("""${frequencyLink}""")
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
-                  .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
+                  .formParam("topic_id", """${emailAlertFrontendTopicId}""")
                   .formParam("frequency", "immediately")
                   .check(
                     css(".checklist-email-signup", "action").saveAs("emailSubscriptionFrequency"),
-                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailSubscriptionFrequencyTopicId"),
+                    css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailAlertFrontendTopicId"),
                     css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
                   .check(status.is(200))
@@ -107,7 +107,7 @@ class DynamicListsEmailSignup extends Simulation {
                 http("POST Email address")
                   .post("""${emailSubscriptionFrequency}""")
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
-                  .formParam("topic_id", """${emailSubscriptionFrequencyTopicId}""")
+                  .formParam("topic_id", """${emailAlertFrontendTopicId}""")
                   .formParam("frequency", "immediately")
                   .formParam("address", "alice@example.com")
                   .check(

--- a/src/test/scala/govuk/DynamicListsEmailSignup.scala
+++ b/src/test/scala/govuk/DynamicListsEmailSignup.scala
@@ -43,7 +43,7 @@ class DynamicListsEmailSignup extends Simulation {
                   .formParam("topic_id", """${emailAlertFrontendTopicId}""")
                   .formParam("frequency", "immediately")
                   .check(
-                    css(".checklist-email-signup", "action").saveAs("emailSubscriptionFrequency"),
+                    css(".checklist-email-signup", "action").saveAs("emailAlertFrontendEmailAddressUrl"),
                     css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailAlertFrontendTopicId"),
                     css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
@@ -51,7 +51,7 @@ class DynamicListsEmailSignup extends Simulation {
               )
               .exec(
                 http("POST Email address")
-                  .post("""${emailSubscriptionFrequency}""")
+                  .post("""${emailAlertFrontendEmailAddressUrl}""")
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .formParam("topic_id", """${emailAlertFrontendTopicId}""")
                   .formParam("frequency", "immediately")
@@ -97,7 +97,7 @@ class DynamicListsEmailSignup extends Simulation {
                   .formParam("topic_id", """${emailAlertFrontendTopicId}""")
                   .formParam("frequency", "immediately")
                   .check(
-                    css(".checklist-email-signup", "action").saveAs("emailSubscriptionFrequency"),
+                    css(".checklist-email-signup", "action").saveAs("emailAlertFrontendEmailAddressUrl"),
                     css(".checklist-email-signup input[name=topic_id]", "value").saveAs("emailAlertFrontendTopicId"),
                     css(".checklist-email-signup input[name=authenticity_token]", "value").saveAs("emailAlertFrontendAuthToken")
                   )
@@ -105,7 +105,7 @@ class DynamicListsEmailSignup extends Simulation {
               )
               .exec(
                 http("POST Email address")
-                  .post("""${emailSubscriptionFrequency}""")
+                  .post("""${emailAlertFrontendEmailAddressUrl}""")
                   .formParam("authenticity_token", """${emailAlertFrontendAuthToken}""")
                   .formParam("topic_id", """${emailAlertFrontendTopicId}""")
                   .formParam("frequency", "immediately")


### PR DESCRIPTION
This renames some variables in the dynamic lists email sign up plan. This is in preparation for them being moved into common scenario and test plans so the variable names are clearer.

This was part of #49 which had to be reverted in #51 so I'm going to try and bring it back in smaller chunks.