### PR TITLE
Add Simulation Plan and postcodes for MapIt

### DIFF
--- a/src/test/scala/govuk/MapIt.scala
+++ b/src/test/scala/govuk/MapIt.scala
@@ -1,0 +1,39 @@
+package govuk
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+class MapIt extends Simulation {
+  val factor = sys.props.getOrElse("factor", "1").toFloat
+  val duration = sys.props.getOrElse("duration", "0").toInt
+
+  val postcodes = csv(dataDir + java.io.File.separatorChar + "postcodes.csv").readRecords
+
+  val scale = factor / workers
+
+  val scn =
+    scenario("MapIt")
+      .feed(cachebuster)
+      .foreach(postcodes, "postcode") {
+        exec(flattenMapIntoAttributes("${postcode}"))
+          .repeat(session => math.ceil(session("hits").as[Int] * scale).toInt,
+                  "hit") {
+            exec(get("${base_path}", "${cachebust}-${hit}"))
+          }
+      }
+
+  val scnWithDuration =
+    scenario("Mapit")
+      .during(duration, "Soak test") {
+        feed(cachebuster)
+        .foreach(postcodes, "postcode") {
+          exec(flattenMapIntoAttributes("${postcode}"))
+            .repeat(session => math.ceil(session("hits").as[Int] * scale).toInt,
+                    "hit") {
+              exec(get("${base_path}", "${cachebust}-${hit}"))
+            }
+        }
+      }
+
+  if (duration == 0) run(scn) else run(scnWithDuration)
+}


### PR DESCRIPTION
This PR adds a basic test plan for loadtesting MapIt.

It contains a very large CSV with paths in the format `/postcode/{POSTCODE}.json`, and to be run against the mapit base path in staging.
