### PR TITLE
Basic school closure test

### DIFF
--- a/src/test/scala/govuk/SchoolClosure.scala
+++ b/src/test/scala/govuk/SchoolClosure.scala
@@ -1,0 +1,21 @@
+package govuk
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+class SchoolClosure extends Simulation {
+  val duration = sys.props.getOrElse("duration", "3600").toInt
+
+  val scn = scenario("Test school closure post requests")
+    .during(duration, "Soak test") {
+      exec(
+        http("check school closures")
+          .post("/check-school-closure")
+          .formParam("postcode", "SW1A 2AA")
+          .disableFollowRedirect
+          .check(status.is(302))
+      )
+    }
+
+  run(scn)
+}


### PR DESCRIPTION
Trello: https://trello.com/c/Gu97ssQ3/730-load-testing-for-local-transaction-pages

This is a test for load testing the quantity of POST requests can be
handled to a particular local transaction, in this case
/school-closure-check. The user process to access these involves accessing
a form, submitting it and then being redirected to a local authority page.

We expect that the form itself will be mostly cached at the CDN and that
there are a limited number of local authority pages that will also
mostly likely be cached, therefore the area to really test is the post
requests that always make it to origin.

This only tests a single postcode as there isn't any caching of
postcodes in the app so testing one postcode repeatedly should have the
same affect as testing a variety of them.