### PR TITLE
Coronavirus local restrictions test

### DIFF
--- a/src/test/scala/govuk/CoronavirusLocalRestrictions.scala
+++ b/src/test/scala/govuk/CoronavirusLocalRestrictions.scala
@@ -1,0 +1,28 @@
+package govuk
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+
+class CoronavirusLocalRestrictions extends Simulation {
+  val postcodes = csv(dataDir + java.io.File.separatorChar + "all_postcodes.csv.gz").unzip.eager
+
+  val duration = sys.props.getOrElse("duration", "3600").toInt
+  var varyingPostcode = sys.props.getOrElse("varyingPostcode", "true").toBoolean
+
+  def localRestrictionsPath(postcode: String, cachebust: String) = {
+    val postcodeToUse = if (varyingPostcode) postcode else "SW1A 2AA"
+    "/find-coronavirus-local-restrictions?postcode=" + postcodeToUse + "&cachebust=" + cachebust
+  }
+
+  val scn = scenario("Load test")
+      .during(duration, "Soak test") {
+        feed(cachebuster)
+          .feed(postcodes.random)
+          .exec(
+            http("Check postcode")
+              .get(localRestrictionsPath("${postcode}", "${cachebust}"))
+          )
+      }
+
+  run(scn)
+}


### PR DESCRIPTION
Trello: https://trello.com/c/mmLXQSQJ/1082-figure-out-how-much-traffic-the-postcode-checker-could-currently-handle

This is a draft while we test this approach out with some load tests. We may tweak it further.

This test sends requests to the find-coronavirus-local-restrictions page
and can be customised to use the same single postcode (SW1A 2AA) for all
requests or to vary them, in order to test postcode caching or not.