### PR TITLE
Add Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,3 +351,7 @@ It may be useful to run multiple concurrent Gatling tests to simulate more load 
       session
     })
     ```
+
+## Licence
+
+[MIT License](LICENCE)


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence